### PR TITLE
Null check faulty key fix

### DIFF
--- a/src/main/java/plus/crates/Key.java
+++ b/src/main/java/plus/crates/Key.java
@@ -68,6 +68,7 @@ public class Key {
         ItemMeta keyItemMeta = keyItem.getItemMeta();
         String title = getName().replaceAll("%type%", getCrate().getName(true));
         keyItemMeta.setDisplayName(title);
+        if (lore == null) lore = getLore();
         keyItemMeta.setLore(lore);
         keyItem.setItemMeta(keyItemMeta);
         if (amount > 1)


### PR DESCRIPTION
Null check before setting item lore in getKeyItem(). This fixes the issue of faulty keys (keys that don't have a lore).