### PR TITLE
Fix non-claimable keys, if serveradmin enabled "Disable Key Swapping" option.

### DIFF
--- a/src/main/java/plus/crates/Listeners/BlockListeners.java
+++ b/src/main/java/plus/crates/Listeners/BlockListeners.java
@@ -138,7 +138,7 @@ public class BlockListeners implements Listener {
 
     @EventHandler
     public void onInventoryClick(InventoryClickEvent event) {
-        if (!cratesPlus.getConfigHandler().isDisableKeySwapping())
+        if (!cratesPlus.getConfigHandler().isDisableKeySwapping() || event.getInventory().getTitle().equals("Claim Crate Keys"))
             return;
         if (!event.getInventory().getType().toString().contains("PLAYER") && event.getCurrentItem() != null) {
             String title;


### PR DESCRIPTION
Steps to reproduce before:
1. Install plugin
2. Set "Disable Key Swapping" in config.yml to true
3. Give keys to offline player
4. Try to claim them