### PR TITLE
Fix startup issue with Multiverse

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -3,7 +3,7 @@ description: ${project.description}
 main: plus.crates.CratesPlus
 version: ${project.version}
 author: Connor Linfoot
-softdepend: [HolographicDisplays,IndividualHolograms]
+softdepend: [HolographicDisplays,IndividualHolograms,Multiverse-Core]
 commands:
   crate:
     description: Main CratesPlus command


### PR DESCRIPTION
The plugin will error out on startup on 1.14.x when trying to load crates. If it loads before Multiverse, it errors out when trying to get locations. Adding a softdepend for Multiverse fixes this.

```
[01:52:10] [Server thread/ERROR]: Error occurred while enabling CratesPlus v4.5.2 (Is it up to date?)
java.lang.NullPointerException: null
	at org.bukkit.Location.getBlock(Location.java:133) ~[patched_1.14.3.jar:git-Paper-124]
	at plus.crates.CratesPlus.loadMetaData(CratesPlus.java:443) ~[?:?]
	at plus.crates.CratesPlus.onEnable(CratesPlus.java:212) ~[?:?]
	at org.bukkit.plugin.java.JavaPlugin.setEnabled(JavaPlugin.java:263) ~[patched_1.14.3.jar:git-Paper-124]
	at org.bukkit.plugin.java.JavaPluginLoader.enablePlugin(JavaPluginLoader.java:338) ~[patched_1.14.3.jar:git-Paper-124]
	at org.bukkit.plugin.SimplePluginManager.enablePlugin(SimplePluginManager.java:419) ~[patched_1.14.3.jar:git-Paper-124]
	at org.bukkit.craftbukkit.v1_14_R1.CraftServer.enablePlugin(CraftServer.java:467) ~[patched_1.14.3.jar:git-Paper-124]
	at org.bukkit.craftbukkit.v1_14_R1.CraftServer.enablePlugins(CraftServer.java:381) ~[patched_1.14.3.jar:git-Paper-124]
	at net.minecraft.server.v1_14_R1.MinecraftServer.a(MinecraftServer.java:464) ~[patched_1.14.3.jar:git-Paper-124]
	at net.minecraft.server.v1_14_R1.DedicatedServer.init(DedicatedServer.java:282) ~[patched_1.14.3.jar:git-Paper-124]
	at net.minecraft.server.v1_14_R1.MinecraftServer.run(MinecraftServer.java:859) ~[patched_1.14.3.jar:git-Paper-124]
	at java.lang.Thread.run(Unknown Source) [?:1.8.0_191]
[01:52:10] [Server thread/INFO]: [CratesPlus] Disabling CratesPlus v4.5.2
```