### PR TITLE
add api-version line

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -2,6 +2,7 @@ name: CratesPlus
 description: ${project.description}
 main: plus.crates.CratesPlus
 version: ${project.version}
+api-version: 1.13
 author: Connor Linfoot
 softdepend: [HolographicDisplays,IndividualHolograms]
 commands:


### PR DESCRIPTION
This is needed to prevent CratesPlus from operating in compatibility mode. 
All item names must use new material names before this can be accepted. 

Spigot's built-in compatibility transformers are not efficient and should not be used.  As CP 5.x is intended for 1.14.x+ this line should be added.  If CP uses old item names, this WILL cause the plugin to fail.

Github made the line 15 -> 16 change noted here. 