### PR TITLE
Fix world loading too late

### DIFF
--- a/src/main/java/plus/crates/CratesPlus.java
+++ b/src/main/java/plus/crates/CratesPlus.java
@@ -301,7 +301,12 @@ public class CratesPlus extends JavaPlugin implements Listener {
                 }
                 Location locationObj;
                 try {
-                    locationObj = new Location(Bukkit.getWorld(strings.get(0)), Double.parseDouble(strings.get(1)), Double.parseDouble(strings.get(2)), Double.parseDouble(strings.get(3)));
+                    World world = Bukkit.getWorld(strings.get(0));
+                    if (world == null) {
+                        getLogger().warning("Crate " + name + " is located in world " + strings.get(0) + " which is currently not loaded and will therefor not work!");
+                        continue;
+                    }
+                    locationObj = new Location(world, Double.parseDouble(strings.get(1)), Double.parseDouble(strings.get(2)), Double.parseDouble(strings.get(3)));
                     Block block = locationObj.getBlock();
                     if (block == null || block.getType().equals(Material.AIR)) {
                         getLogger().warning("No block found at " + location + " removing from data.yml");

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -3,7 +3,7 @@ description: ${project.description}
 main: plus.crates.CratesPlus
 version: ${project.version}
 author: Connor Linfoot
-softdepend: [HolographicDisplays,IndividualHolograms]
+softdepend: [HolographicDisplays,IndividualHolograms,Multiverse-Core]
 commands:
   crate:
     description: Main CratesPlus command


### PR DESCRIPTION
When the plugin enables with Multiverse-Core being present on the server, it cannot find the crates specified in the config because the world has not been loaded yet. Previously the plugin failed to enable with a NullPointerException. I added a warning for the world not being loaded and I added Multiverse-Core as a softdepend so that it'll get loaded before this plugin.